### PR TITLE
DPR2-250: Make file transfer lambda domain configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  reporting: ministryofjustice/hmpps-reporting@1.0.37
+  reporting: ministryofjustice/hmpps-reporting@1.0.44
   slack: circleci/slack@4.12.5
 
 workflows:

--- a/src/main/java/uk/gov/justice/digital/clients/s3/S3Client.java
+++ b/src/main/java/uk/gov/justice/digital/clients/s3/S3Client.java
@@ -20,6 +20,11 @@ public class S3Client {
         this.s3 = s3Provider.buildClient();
     }
 
+    public List<String> getObjectsOlderThan(String bucket, String extension, Long retentionDays, Clock clock) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket);
+        return listObjects(extension, retentionDays, clock, request);
+    }
+
     public List<String> getObjectsOlderThan(
             String bucket,
             String folder,
@@ -27,10 +32,13 @@ public class S3Client {
             Long retentionDays,
             Clock clock
     ) {
-        List<String> objectPaths = new LinkedList<>();
         ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withPrefix(folder);
-        LocalDateTime currentDate = LocalDateTime.now(clock);
+        return listObjects(extension, retentionDays, clock, request);
+    }
 
+    private List<String> listObjects(String extension, Long retentionDays, Clock clock, ListObjectsRequest request) {
+        LocalDateTime currentDate = LocalDateTime.now(clock);
+        List<String> objectPaths = new LinkedList<>();
         ObjectListing objectList;
         do {
             objectList = s3.listObjects(request);
@@ -54,5 +62,9 @@ public class S3Client {
     public void moveObject(String objectKey, String sourceBucket, String destinationBucket) {
         s3.copyObject(sourceBucket, objectKey, destinationBucket, objectKey);
         s3.deleteObject(sourceBucket, objectKey);
+    }
+
+    public String getObject(String objectKey, String sourceBucket) {
+        return s3.getObjectAsString(sourceBucket, objectKey);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/common/ConfigSourceDetails.java
+++ b/src/main/java/uk/gov/justice/digital/common/ConfigSourceDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.common;
+
+public class ConfigSourceDetails {
+
+    private final String bucket;
+    private final String configKey;
+
+    public ConfigSourceDetails(String bucket, String configKey) {
+        this.bucket = bucket;
+        this.configKey = configKey;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/common/Utils.java
+++ b/src/main/java/uk/gov/justice/digital/common/Utils.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.common;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public class Utils {
@@ -10,9 +12,21 @@ public class Utils {
     public final static String REPLICATION_TASK_ARN_KEY = "replicationTaskArn";
     public final static String DELIMITER = "/";
     public final static String FILE_EXTENSION = ".parquet";
+    public final static String CONFIG_PATH = "configs/";
+    public final static String CONFIG_FILE_SUFFIX = "_config.json";
 
     public static Optional<String> getOptionalString(Map<String, Object> event, String key) {
         return Optional.ofNullable(event.get(key)).map(obj -> (String) obj);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> getConfig(Map<String, Object> event, String key) {
+        return (Map<String, String>) event.getOrDefault(key, Collections.emptyMap());
+    }
+
+    public static <T, O> T getOrThrow(Map<String, O> obj, String key, Class<T> type) {
+        return Optional.ofNullable(type.cast(obj.get(key)))
+                .orElseThrow(() -> new NoSuchElementException("Required key [" + key + "] is missing"));
     }
 
     private Utils() { }

--- a/src/main/java/uk/gov/justice/digital/lambda/S3FileTransferLambda.java
+++ b/src/main/java/uk/gov/justice/digital/lambda/S3FileTransferLambda.java
@@ -8,15 +8,13 @@ import uk.gov.justice.digital.clients.s3.DefaultS3Provider;
 import uk.gov.justice.digital.clients.s3.S3Client;
 import uk.gov.justice.digital.clients.stepfunctions.DefaultStepFunctionsProvider;
 import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+import uk.gov.justice.digital.common.ConfigSourceDetails;
 import uk.gov.justice.digital.services.S3FileTransferService;
 
 import java.time.Clock;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import static uk.gov.justice.digital.common.Utils.TASK_TOKEN_KEY;
-import static uk.gov.justice.digital.common.Utils.getOptionalString;
+import static uk.gov.justice.digital.common.Utils.*;
 
 /**
  * This Lambda moves parquet files from a source bucket to a destination bucket
@@ -26,7 +24,10 @@ import static uk.gov.justice.digital.common.Utils.getOptionalString;
  *    "sourceBucket": "some-source-bucket",
  *    "destinationBucket": "some-destination-bucket",
  *    "retentionDays": "0",
- *    "sourceFolder": "some/folder"
+ *    "config": {
+ *      "key": "domain",
+ *      "bucket": "some-config-bucket"
+ *    }
  * }
  * </pre>
  * Only files with the lastModifiedDate older than the current date-time - retentionDays will be moved.
@@ -38,8 +39,14 @@ public class S3FileTransferLambda implements RequestHandler<Map<String, Object>,
 
     public final static String SOURCE_BUCKET_KEY = "sourceBucket";
     public final static String DESTINATION_BUCKET_KEY = "destinationBucket";
-    // Optional folder(s) where files are located. Files outside specified folder are ignored
-    public final static String SOURCE_FOLDER_KEY = "sourceFolder";
+
+    // Optional config. When missing, all files will be archived.
+    public final static String CONFIG_OBJECT_KEY = "config";
+
+    // Config key which maps to a list of tables. Only files belonging to those tables will be archived.
+    public final static String CONFIG_KEY = "key";
+    // S3 bucket name where the configs are located
+    public final static String CONFIG_BUCKET = "bucket";
     // Optional field defaults to 0 (i.e. delete all files with modified date-time older than current date-time)
     public final static String RETENTION_DAYS_KEY = "retentionDays";
 
@@ -65,18 +72,30 @@ public class S3FileTransferLambda implements RequestHandler<Map<String, Object>,
     public Void handleRequest(Map<String, Object> event, Context context) {
 
         LambdaLogger logger = context.getLogger();
-        final String sourceBucket = (String) event.get(SOURCE_BUCKET_KEY);
-        final String destinationBucket = (String) event.get(DESTINATION_BUCKET_KEY);
-        final String sourceFolder = getOptionalString(event, SOURCE_FOLDER_KEY).orElse("");
+        final String sourceBucket = getOrThrow(event, SOURCE_BUCKET_KEY, String.class);
+        final String destinationBucket = getOrThrow(event, DESTINATION_BUCKET_KEY, String.class);
         final Long retentionDays = getOptionalString(event, RETENTION_DAYS_KEY)
                 .map(Long::parseLong)
                 .orElse(DEFAULT_RETENTION_DAYS);
 
         // Optional task token. Present when triggered from step function. Absent when triggered from cloudwatch schedule
         final String token = (String) event.get(TASK_TOKEN_KEY);
+        final Map<String, String> config = getConfig(event, CONFIG_OBJECT_KEY);
 
-        logger.log("Listing files in S3 source location: " + sourceBucket, LogLevel.INFO);
-        List<String> objectKeys = service.listParquetFiles(sourceBucket, sourceFolder, retentionDays);
+        List<String> objectKeys = new ArrayList<>();
+        if (config.isEmpty()) {
+            // When no config is provided, all files in s3 bucket are archived
+            logger.log("Listing files in S3 source location: " + sourceBucket, LogLevel.INFO);
+            objectKeys.addAll(service.listParquetFiles(sourceBucket, retentionDays));
+        } else {
+            // When config is provided, only files belonging to the configured tables are archived
+            String configBucket = getOrThrow(config, CONFIG_BUCKET, String.class);
+            String configKey = getOrThrow(config, CONFIG_KEY, String.class);
+
+            logger.log(String.format("Listing files in S3 source location %s for domain %s", sourceBucket, configKey), LogLevel.INFO);
+            ConfigSourceDetails configDetails = new ConfigSourceDetails(configBucket, configKey);
+            objectKeys.addAll(service.listParquetFilesForConfig(sourceBucket, configDetails, retentionDays));
+        }
 
         logger.log(String.format("Moving S3 objects older than %d day(s) from %s to %s", retentionDays, sourceBucket, destinationBucket));
         Set<String> failedObjects = service.moveObjects(logger, objectKeys, sourceBucket, destinationBucket, token);

--- a/src/test/java/uk/gov/justice/digital/services/test/Fixture.java
+++ b/src/test/java/uk/gov/justice/digital/services/test/Fixture.java
@@ -1,30 +1,17 @@
 package uk.gov.justice.digital.services.test;
 
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.Matchers.contains;
 
 public class Fixture {
-
-    public final static String TEST_TOKEN = "test-token";
 
     public static final ZoneId utcZoneId = ZoneId.of("UTC");
 
     public static final LocalDateTime fixedDateTime = LocalDateTime.now();
 
     public static Clock fixedClock = Clock.fixed(fixedDateTime.toInstant(ZoneOffset.UTC), utcZoneId);
-
-    public static <T> Matcher<Iterable<? extends T>> containsTheSameElementsInOrderAs(List<T> expectedItems) {
-        return contains(expectedItems.stream().map(Matchers::equalTo).collect(Collectors.toList()));
-    }
 
     private Fixture() {}
 }


### PR DESCRIPTION
This PR allows the file transfer to be applied to a configurable list of tables.
- The config is read from s3 bucket using a domain key
- The JSON payload which will be passed to the lambda will look like:
```
{
  "sourceBucket": "source-bucket-name",
  "destinationBucket": "archive-bucket-name",
  "retentionDays": "0",
  "config": {
    "key": "domain-key",
    "bucket": "config-bucket-name"
  }
}
```
- The config JSON object optional and when not provided, all files are archived