### PR TITLE
DPR2-46: Implement delete and stop-glue-job lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-s3:$amazonSdkVersion"
     implementation "com.amazonaws:aws-java-sdk-dynamodb:$amazonSdkVersion"
     implementation "com.amazonaws:aws-java-sdk-stepfunctions:$amazonSdkVersion"
+    implementation "com.amazonaws:aws-java-sdk-glue:$amazonSdkVersion"
     implementation "com.amazonaws:aws-lambda-java-core:$lambdaCoreVersion"
     implementation "com.amazonaws:aws-lambda-java-events:$lambdaJavaEventsVersion"
 

--- a/src/it/java/lambda/S3DataDeletionLambdaIntegrationTest.java
+++ b/src/it/java/lambda/S3DataDeletionLambdaIntegrationTest.java
@@ -1,0 +1,151 @@
+package lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.clients.s3.S3Client;
+import uk.gov.justice.digital.clients.s3.S3Provider;
+import uk.gov.justice.digital.lambda.S3DataDeletionLambda;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.gov.justice.digital.common.Utils.*;
+import static uk.gov.justice.digital.lambda.S3FileTransferLambda.*;
+
+@ExtendWith(MockitoExtension.class)
+public class S3DataDeletionLambdaIntegrationTest {
+
+    @Mock
+    private Context contextMock;
+    @Mock
+    private LambdaLogger mockLogger;
+    @Mock
+    private S3Provider mockS3Provider;
+    @Mock
+    private AmazonS3 mockS3;
+    @Mock
+    private ObjectListing mockObjectListing;
+
+    @Captor
+    ArgumentCaptor<String> sourceKeyCaptor, deleteKeyCaptor;
+
+    @Captor
+    ArgumentCaptor<ListObjectsRequest> listObjectsRequestCaptor;
+
+    private final static String SOURCE_BUCKET = "source-bucket";
+
+    private S3DataDeletionLambda underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(contextMock, mockLogger, mockS3Provider, mockS3, mockObjectListing);
+
+        when(contextMock.getLogger()).thenReturn(mockLogger);
+        doNothing().when(mockLogger).log(anyString(), any());
+        when(mockS3Provider.buildClient()).thenReturn(mockS3);
+
+        underTest = new S3DataDeletionLambda(new S3Client(mockS3Provider));
+    }
+
+    @Test
+    public void shouldDeleteParquetObjects() {
+        Map<String, Object> event = createEvent();
+
+        List<S3ObjectSummary> objectSummaries = createObjectSummaries(new Date());
+
+        List<String> expectedKeys = new ArrayList<>();
+        expectedKeys.add("1.parquet");
+        expectedKeys.add("3.parquet");
+
+        mockS3ObjectListing(objectSummaries);
+
+        underTest.handleRequest(event, contextMock);
+
+        verify(mockS3, times(expectedKeys.size())).deleteObject(
+                eq(SOURCE_BUCKET),
+                sourceKeyCaptor.capture()
+        );
+
+        assertThat(listObjectsRequestCaptor.getValue().getPrefix(), is(nullValue()));
+        assertThat(sourceKeyCaptor.getAllValues(), containsInAnyOrder(expectedKeys.toArray()));
+
+        verify(mockS3, times(expectedKeys.size())).deleteObject(eq(SOURCE_BUCKET), deleteKeyCaptor.capture());
+
+        assertThat(deleteKeyCaptor.getAllValues(), containsInAnyOrder(expectedKeys.toArray()));
+    }
+
+    @Test
+    public void shouldOnlyDeleteFilesBelongingToConfiguredTables() {
+        String configKey = "test-config-key";
+        String configBucket = "test-config-bucket";
+
+        String configuredTable1 = "schema_1/table_1";
+        String configuredTable2 = "schema_2/table_2";
+
+        Map<String, Object> event = createEvent();
+        event.put(CONFIG_OBJECT_KEY, Map.of(CONFIG_KEY, configKey, CONFIG_BUCKET, configBucket));
+
+        Date lastModifiedDate = Date.from(new Date().toInstant());
+        List<S3ObjectSummary> objectSummaries = createObjectSummaries(lastModifiedDate);
+
+        mockS3ObjectListing(objectSummaries);
+        when(mockS3.getObjectAsString(configBucket, CONFIG_PATH + configKey + CONFIG_FILE_SUFFIX))
+                .thenReturn("{\"tables\": [\"" + configuredTable1 + "\", \"" + configuredTable2 + "\"]}");
+
+        underTest.handleRequest(event, contextMock);
+
+        assertThat(
+                listObjectsRequestCaptor.getAllValues().stream().map(ListObjectsRequest::getPrefix).collect(Collectors.toList()),
+                containsInAnyOrder(configuredTable1 + DELIMITER, configuredTable2 + DELIMITER)
+        );
+
+        verify(mockS3, times(4)).deleteObject(eq(SOURCE_BUCKET), deleteKeyCaptor.capture());
+        assertThat(deleteKeyCaptor.getAllValues(), containsInAnyOrder("1.parquet", "3.parquet", "1.parquet", "3.parquet"));
+    }
+
+    private Map<String, Object> createEvent() {
+        Map<String, Object> event = new HashMap<>();
+        event.put(SOURCE_BUCKET_KEY, SOURCE_BUCKET);
+        return event;
+    }
+
+    private S3ObjectSummary createObjectSummary(String key, Date lastModifiedDate) {
+        S3ObjectSummary objectSummary = new S3ObjectSummary();
+        objectSummary.setKey(key);
+        objectSummary.setLastModified(lastModifiedDate);
+
+        return objectSummary;
+    }
+
+    private void mockS3ObjectListing(List<S3ObjectSummary> objectSummaries) {
+        when(mockS3.listObjects(listObjectsRequestCaptor.capture())).thenReturn(mockObjectListing);
+        when(mockObjectListing.getObjectSummaries()).thenReturn(objectSummaries);
+        when(mockObjectListing.getMarker()).thenReturn(null);
+        when(mockObjectListing.isTruncated()).thenReturn(false);
+    }
+
+    private List<S3ObjectSummary> createObjectSummaries(Date lastModifiedDate) {
+        List<S3ObjectSummary> objectSummaries = new ArrayList<>();
+        objectSummaries.add(createObjectSummary("1.parquet", lastModifiedDate));
+        objectSummaries.add(createObjectSummary("3.parquet", lastModifiedDate));
+        return objectSummaries;
+    }
+}

--- a/src/it/java/lambda/StopGlueJobLambdaIntegrationTest.java
+++ b/src/it/java/lambda/StopGlueJobLambdaIntegrationTest.java
@@ -1,0 +1,89 @@
+package lambda;
+
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchStopJobRunRequest;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.stepfunctions.AWSStepFunctions;
+import com.amazonaws.services.stepfunctions.model.SendTaskSuccessRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.clients.glue.GlueClient;
+import uk.gov.justice.digital.clients.glue.GlueProvider;
+import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsProvider;
+import uk.gov.justice.digital.lambda.StopGlueJobLambda;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static lambda.test.Fixture.TEST_GLUE_JOB;
+import static lambda.test.Fixture.TEST_TOKEN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.Utils.TASK_TOKEN_KEY;
+import static uk.gov.justice.digital.lambda.StopGlueJobLambda.GLUE_JOB_NAME;
+
+@ExtendWith(MockitoExtension.class)
+public class StopGlueJobLambdaIntegrationTest {
+
+    @Mock
+    private Context contextMock;
+    @Mock
+    private LambdaLogger mockLogger;
+    @Mock
+    private GlueProvider glueProvider;
+    @Mock
+    private StepFunctionsProvider stepFunctionProvider;
+    @Mock
+    private AWSGlue mockAwsGlue;
+    @Mock
+    private AWSStepFunctions mockStepFunctions;
+
+    @Captor
+    ArgumentCaptor<BatchStopJobRunRequest> batchStopJobRequestCaptor;
+    @Captor
+    ArgumentCaptor<SendTaskSuccessRequest> sendStepFunctionsSuccessRequestCaptor;
+
+    private StopGlueJobLambda underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(contextMock, mockLogger, mockAwsGlue, mockStepFunctions);
+
+        when(contextMock.getLogger()).thenReturn(mockLogger);
+        doNothing().when(mockLogger).log(anyString(), any());
+
+        when(glueProvider.buildClient()).thenReturn(mockAwsGlue);
+        when(stepFunctionProvider.buildClient()).thenReturn(mockStepFunctions);
+
+        underTest = new StopGlueJobLambda(new GlueClient(glueProvider), new StepFunctionsClient(stepFunctionProvider));
+    }
+
+    @Test
+    public void shouldStopGlueJobAndNotifyStepFunction() {
+        Map<String, Object> event = new HashMap<>();
+        event.put(GLUE_JOB_NAME, TEST_GLUE_JOB);
+        event.put(TASK_TOKEN_KEY, TEST_TOKEN);
+
+        underTest.handleRequest(event, contextMock);
+
+        verify(mockAwsGlue, times(1)).batchStopJobRun(batchStopJobRequestCaptor.capture());
+        verify(mockStepFunctions, times(1))
+                .sendTaskSuccess(sendStepFunctionsSuccessRequestCaptor.capture());
+
+        assertThat(batchStopJobRequestCaptor.getValue().getJobName(), is(equalTo(TEST_GLUE_JOB)));
+        assertThat(sendStepFunctionsSuccessRequestCaptor.getValue().getTaskToken(), is(equalTo(TEST_TOKEN)));
+    }
+
+}

--- a/src/it/java/lambda/test/Fixture.java
+++ b/src/it/java/lambda/test/Fixture.java
@@ -8,6 +8,9 @@ import java.time.ZoneOffset;
 public class Fixture {
 
     public final static String TEST_TOKEN = "test-token";
+    public final static String TEST_GLUE_JOB = "test-glue-job";
+
+    public static final String TEST_JOB_NAME = "test-job-name";
 
     public static final ZoneId utcZoneId = ZoneId.of("UTC");
 

--- a/src/main/java/uk/gov/justice/digital/clients/glue/DefaultGlueProvider.java
+++ b/src/main/java/uk/gov/justice/digital/clients/glue/DefaultGlueProvider.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.clients.glue;
+
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
+
+import static uk.gov.justice.digital.common.Utils.DEFAULT_DPR_REGION;
+
+public class DefaultGlueProvider implements GlueProvider {
+    @Override
+    public AWSGlue buildClient() {
+        return AWSGlueClientBuilder.standard().withRegion(DEFAULT_DPR_REGION).build();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/clients/glue/GlueClient.java
+++ b/src/main/java/uk/gov/justice/digital/clients/glue/GlueClient.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.clients.glue;
+
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchStopJobRunRequest;
+
+public class GlueClient {
+
+    private final AWSGlue glueClient;
+
+    public GlueClient(GlueProvider glueProvider) {
+        this.glueClient = glueProvider.buildClient();
+    }
+
+    public void stopJob(String jobName) {
+        BatchStopJobRunRequest request = new BatchStopJobRunRequest().withJobName(jobName);
+        glueClient.batchStopJobRun(request);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/clients/glue/GlueProvider.java
+++ b/src/main/java/uk/gov/justice/digital/clients/glue/GlueProvider.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.clients.glue;
+
+import com.amazonaws.services.glue.AWSGlue;
+
+public interface GlueProvider {
+    AWSGlue buildClient();
+}

--- a/src/main/java/uk/gov/justice/digital/clients/s3/S3Client.java
+++ b/src/main/java/uk/gov/justice/digital/clients/s3/S3Client.java
@@ -67,4 +67,8 @@ public class S3Client {
     public String getObject(String objectKey, String sourceBucket) {
         return s3.getObjectAsString(sourceBucket, objectKey);
     }
+
+    public void deleteObject(String objectKey, String sourceBucket) {
+        s3.deleteObject(sourceBucket, objectKey);
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/clients/stepfunctions/StepFunctionsClient.java
+++ b/src/main/java/uk/gov/justice/digital/clients/stepfunctions/StepFunctionsClient.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.clients.stepfunctions;
 
 import com.amazonaws.services.stepfunctions.AWSStepFunctions;
+import com.amazonaws.services.stepfunctions.model.SendTaskFailureRequest;
 import com.amazonaws.services.stepfunctions.model.SendTaskSuccessRequest;
 
 public class StepFunctionsClient {
@@ -11,10 +12,17 @@ public class StepFunctionsClient {
         this.stepFunctions = stepFunctionsProvider.buildClient();
     }
 
-    public void notifyStepFunction(String retrievedToken) {
+    public void notifyStepFunctionSuccess(String retrievedToken) {
         SendTaskSuccessRequest taskSuccessRequest = new SendTaskSuccessRequest()
                 .withTaskToken(retrievedToken)
                 .withOutput("{}");
         stepFunctions.sendTaskSuccess(taskSuccessRequest);
+    }
+
+    public void notifyStepFunctionFailure(String retrievedToken, String error) {
+        SendTaskFailureRequest taskFailureRequest = new SendTaskFailureRequest()
+                .withTaskToken(retrievedToken)
+                .withError(error);
+        stepFunctions.sendTaskFailure(taskFailureRequest);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/lambda/S3DataDeletionLambda.java
+++ b/src/main/java/uk/gov/justice/digital/lambda/S3DataDeletionLambda.java
@@ -12,33 +12,29 @@ import uk.gov.justice.digital.common.ConfigSourceDetails;
 import uk.gov.justice.digital.services.S3FileService;
 
 import java.time.Clock;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static uk.gov.justice.digital.common.Utils.*;
 
 /**
- * This Lambda moves parquet files from a source bucket to a destination bucket
+ * This Lambda deletes objects from a source bucket
  * using the following JSON event structure
  * <pre>
  * {
  *    "sourceBucket": "some-source-bucket",
- *    "destinationBucket": "some-destination-bucket",
- *    "retentionDays": "0",
  *    "config": {
  *      "key": "domain",
  *      "bucket": "some-config-bucket"
  *    }
  * }
  * </pre>
- * Only files with the lastModifiedDate older than the current date-time - retentionDays will be moved.
- * Files which failed to be copied will not be deleted.
  */
-public class S3FileTransferLambda implements RequestHandler<Map<String, Object>, Void> {
-
-    final static Long DEFAULT_RETENTION_DAYS = 0L;
+public class S3DataDeletionLambda implements RequestHandler<Map<String, Object>, Void> {
 
     public final static String SOURCE_BUCKET_KEY = "sourceBucket";
-    public final static String DESTINATION_BUCKET_KEY = "destinationBucket";
 
     // Optional config. When missing, all files will be archived.
     public final static String CONFIG_OBJECT_KEY = "config";
@@ -48,24 +44,25 @@ public class S3FileTransferLambda implements RequestHandler<Map<String, Object>,
     // S3 bucket name where the configs are located
     public final static String CONFIG_BUCKET = "bucket";
     // Optional field defaults to 0 (i.e. delete all files with modified date-time older than current date-time)
-    public final static String RETENTION_DAYS_KEY = "retentionDays";
 
     private final S3FileService service;
 
     @SuppressWarnings("unused")
-    public S3FileTransferLambda() {
+    public S3DataDeletionLambda() {
         S3Client s3Client = new S3Client(new DefaultS3Provider());
-        StepFunctionsClient stepFunctionsClient = new StepFunctionsClient(new DefaultStepFunctionsProvider());
-        Clock clock = Clock.systemUTC();
-        this.service = new S3FileService(s3Client, stepFunctionsClient, clock);
+        this.service = new S3FileService(
+                s3Client,
+                new StepFunctionsClient(new DefaultStepFunctionsProvider()),
+                Clock.systemUTC()
+        );
     }
 
-    public S3FileTransferLambda(
-            S3Client s3Client,
-            StepFunctionsClient stepFunctionsClient,
-            Clock clock
-    ) {
-        this.service = new S3FileService(s3Client, stepFunctionsClient, clock);
+    public S3DataDeletionLambda(S3Client s3Client) {
+        this.service = new S3FileService(
+                s3Client,
+                new StepFunctionsClient(new DefaultStepFunctionsProvider()),
+                Clock.systemUTC()
+        );
     }
 
     @Override
@@ -73,20 +70,14 @@ public class S3FileTransferLambda implements RequestHandler<Map<String, Object>,
 
         LambdaLogger logger = context.getLogger();
         final String sourceBucket = getOrThrow(event, SOURCE_BUCKET_KEY, String.class);
-        final String destinationBucket = getOrThrow(event, DESTINATION_BUCKET_KEY, String.class);
-        final Long retentionDays = getOptionalString(event, RETENTION_DAYS_KEY)
-                .map(Long::parseLong)
-                .orElse(DEFAULT_RETENTION_DAYS);
 
-        // Optional task token. Present when triggered from step function. Absent when triggered from cloudwatch schedule
-        final String token = (String) event.get(TASK_TOKEN_KEY);
         final Map<String, String> config = getConfig(event, CONFIG_OBJECT_KEY);
 
         List<String> objectKeys = new ArrayList<>();
         if (config.isEmpty()) {
             // When no config is provided, all files in s3 bucket are archived
             logger.log("Listing files in S3 source location: " + sourceBucket, LogLevel.INFO);
-            objectKeys.addAll(service.listParquetFiles(sourceBucket, retentionDays));
+            objectKeys.addAll(service.listParquetFiles(sourceBucket, 0L));
         } else {
             // When config is provided, only files belonging to the configured tables are archived
             String configBucket = getOrThrow(config, CONFIG_BUCKET, String.class);
@@ -94,16 +85,16 @@ public class S3FileTransferLambda implements RequestHandler<Map<String, Object>,
 
             logger.log(String.format("Listing files in S3 source location %s for domain %s", sourceBucket, configKey), LogLevel.INFO);
             ConfigSourceDetails configDetails = new ConfigSourceDetails(configBucket, configKey);
-            objectKeys.addAll(service.listParquetFilesForConfig(sourceBucket, configDetails, retentionDays));
+            objectKeys.addAll(service.listParquetFilesForConfig(sourceBucket, configDetails, 0L));
         }
 
-        logger.log(String.format("Moving S3 objects older than %d day(s) from %s to %s", retentionDays, sourceBucket, destinationBucket));
-        Set<String> failedObjects = service.moveObjects(logger, objectKeys, sourceBucket, destinationBucket, token);
+        logger.log(String.format("Deleting S3 objects from %s ", sourceBucket));
+        Set<String> failedObjects = service.deleteObjects(logger, objectKeys, sourceBucket);
 
         if (failedObjects.isEmpty()) {
-            logger.log(String.format("Successfully moved %d S3 files", objectKeys.size()), LogLevel.INFO);
+            logger.log(String.format("Successfully deleted %d S3 files", objectKeys.size()), LogLevel.INFO);
         } else {
-            logger.log("Not all S3 files were moved", LogLevel.WARN);
+            logger.log("Not all S3 files were deleted", LogLevel.WARN);
             System.exit(1);
         }
         return null;

--- a/src/main/java/uk/gov/justice/digital/lambda/StopGlueJobLambda.java
+++ b/src/main/java/uk/gov/justice/digital/lambda/StopGlueJobLambda.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import uk.gov.justice.digital.clients.glue.DefaultGlueProvider;
+import uk.gov.justice.digital.clients.glue.GlueClient;
+import uk.gov.justice.digital.clients.stepfunctions.DefaultStepFunctionsProvider;
+import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+import uk.gov.justice.digital.services.GlueService;
+
+import java.util.Map;
+
+import static uk.gov.justice.digital.common.Utils.TASK_TOKEN_KEY;
+import static uk.gov.justice.digital.common.Utils.getOrThrow;
+
+/**
+ * This Lambda stops a running glue job and notifies the step function whether it succeeded or failed
+ * using the following JSON event structure
+ * <pre>
+ * {
+ *    "glueJob": "some-source-bucket",
+ *    "token": "step-functions-task-token"
+ * }
+ * </pre>
+ */
+public class StopGlueJobLambda implements RequestHandler<Map<String, Object>, Void> {
+
+    public final static String GLUE_JOB_NAME = "glueJobName";
+
+    private final GlueService service;
+
+    @SuppressWarnings("unused")
+    public StopGlueJobLambda() {
+        GlueClient glueClient = new GlueClient(new DefaultGlueProvider());
+        StepFunctionsClient stepFunctionsClient = new StepFunctionsClient(new DefaultStepFunctionsProvider());
+        this.service = new GlueService(glueClient, stepFunctionsClient);
+    }
+
+    public StopGlueJobLambda(GlueClient glueClient, StepFunctionsClient stepFunctionsClient) {
+        this.service = new GlueService(glueClient, stepFunctionsClient);
+    }
+
+    @Override
+    public Void handleRequest(Map<String, Object> event, Context context) {
+        LambdaLogger logger = context.getLogger();
+        final String glueJobName = getOrThrow(event, GLUE_JOB_NAME, String.class);
+        final String inputToken = getOrThrow(event, TASK_TOKEN_KEY, String.class);
+
+        service.stopJob(logger, glueJobName, inputToken);
+
+        return null;
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/services/GlueService.java
+++ b/src/main/java/uk/gov/justice/digital/services/GlueService.java
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.services;
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.logging.LogLevel;
+import uk.gov.justice.digital.clients.glue.GlueClient;
+import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+
+public class GlueService {
+
+    private final GlueClient glueClient;
+    private final StepFunctionsClient stepFunctionsClient;
+
+    public GlueService(
+            GlueClient glueClient,
+            StepFunctionsClient stepFunctionsClient
+    ) {
+        this.glueClient = glueClient;
+        this.stepFunctionsClient = stepFunctionsClient;
+    }
+
+    public void stopJob(LambdaLogger logger, String jobName, String token) {
+        try {
+            logger.log(String.format("Stopping Glue job %s", jobName), LogLevel.INFO);
+            glueClient.stopJob(jobName);
+            logger.log(String.format("Stopped Glue job %s", jobName), LogLevel.INFO);
+            logger.log(String.format("Notifying step functions of success using token %s", token), LogLevel.INFO);
+            stepFunctionsClient.notifyStepFunctionSuccess(token);
+        } catch (Exception ex) {
+            logger.log(String.format("Failed to stop glue job %s", ex.getMessage()), LogLevel.ERROR);
+            logger.log(String.format("Notifying step functions of failure using token %s", token), LogLevel.INFO);
+            stepFunctionsClient.notifyStepFunctionFailure(token, ex.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationService.java
+++ b/src/main/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationService.java
@@ -36,7 +36,7 @@ public class StepFunctionDMSNotificationService {
 
         retrievedToken.ifPresent(token -> {
                     logger.log(String.format("Notifying step functions of success using token %s", token), LogLevel.INFO);
-                    stepFunctionsClient.notifyStepFunction(token);
+                    stepFunctionsClient.notifyStepFunctionSuccess(token);
                 }
         );
 

--- a/src/test/java/uk/gov/justice/digital/services/GlueServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/services/GlueServiceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.services;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.clients.glue.GlueClient;
+import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GlueServiceTest {
+
+    @Mock
+    GlueClient mockGlueClient;
+    @Mock
+    StepFunctionsClient mockStepFunctionsClient;
+
+    @Mock
+    LambdaLogger mockLambdaLogger;
+
+    public final static String TEST_TOKEN = "test-token";
+
+    public static final String TEST_JOB_NAME = "test-job-name";
+
+    private GlueService undertest;
+
+    @BeforeEach
+    public void setup() {
+        undertest = new GlueService(mockGlueClient, mockStepFunctionsClient);
+    }
+
+    @Test
+    public void shouldCallGlueClientToStopJobAndNotifyStepFunction() {
+        assertDoesNotThrow(() -> undertest.stopJob(mockLambdaLogger, TEST_JOB_NAME, TEST_TOKEN));
+
+        verify(mockGlueClient, times(1)).stopJob(TEST_JOB_NAME);
+        verify(mockStepFunctionsClient, times(1)).notifyStepFunctionSuccess(TEST_TOKEN);
+    }
+
+    @Test
+    public void shouldNotifyStepFunctionOfFailureWhenErrorOccursDuringGlueJobTermination() throws Exception {
+        String errorMessage = "client exception";
+        doThrow(new AmazonClientException(errorMessage)).when(mockGlueClient).stopJob(TEST_JOB_NAME);
+
+        SystemLambda.catchSystemExit(() -> undertest.stopJob(mockLambdaLogger, TEST_JOB_NAME, TEST_TOKEN));
+
+        verify(mockStepFunctionsClient, times(1)).notifyStepFunctionFailure(TEST_TOKEN, errorMessage);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationServiceTest.java
@@ -47,7 +47,7 @@ class StepFunctionDMSNotificationServiceTest {
 
         undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN);
 
-        verify(mockStepFunctionsClient, times(1)).notifyStepFunction(eq(TOKEN));
+        verify(mockStepFunctionsClient, times(1)).notifyStepFunctionSuccess(eq(TOKEN));
         verify(mockDynamoDbClient, times(1)).deleteToken(eq(TABLE), any());
     }
 


### PR DESCRIPTION
This adds two lambda functions which:
- Delete parquet files within a bucket for a configured set of tables
- Stop a glue job and notify the step-function of the result