### PR TITLE
[DPR2-991] Handle maximum AWS SQL batch size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 group 'uk.gov.justice'
 
-version "${version != 'unspecified' ? version : '0.0.1-SNAPSHOT'}"
+version "${version != 'unspecified' ? version : '0.0.9-SNAPSHOT'}"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
The maximum number of SQL statements that can be executed in a batch is 40: https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_BatchExecuteStatement.html#API_BatchExecuteStatement_RequestSyntax