### PR TITLE
DPR2-1925: Process failed DMS task events

### DIFF
--- a/src/main/java/uk/gov/justice/digital/clients/dynamo/DynamoDbClient.java
+++ b/src/main/java/uk/gov/justice/digital/clients/dynamo/DynamoDbClient.java
@@ -1,13 +1,19 @@
 package uk.gov.justice.digital.clients.dynamo;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.*;
+import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+import uk.gov.justice.digital.common.TaskDetail;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.justice.digital.common.Utils.REPLICATION_TASK_ARN_KEY;
 import static uk.gov.justice.digital.common.Utils.TASK_TOKEN_KEY;
+import static uk.gov.justice.digital.common.Utils.IGNORE_DMS_TASK_FAILURE_KEY;
 
 public class DynamoDbClient {
 
@@ -25,18 +31,24 @@ public class DynamoDbClient {
         dynamoDbClient.deleteItem(deleteItemRequest);
     }
 
-    public Optional<String> retrieveToken(String table, Map<String, AttributeValue> itemKey) {
+    public Optional<TaskDetail> retrieveTaskDetail(String table, Map<String, AttributeValue> itemKey) {
         GetItemRequest getTokenRequest = new GetItemRequest(table, itemKey);
         GetItemResult getTokenResult = dynamoDbClient.getItem(getTokenRequest);
 
-        return Optional.ofNullable(getTokenResult.getItem().get(TASK_TOKEN_KEY)).map(AttributeValue::getS);
+        Map<String, AttributeValue> item = getTokenResult.getItem();
+        Optional<String> optionalTaskKey = Optional.ofNullable(item.get(TASK_TOKEN_KEY)).map(AttributeValue::getS);
+        boolean ignoreTaskFailure = item.getOrDefault(IGNORE_DMS_TASK_FAILURE_KEY, new AttributeValue().withBOOL(false)).getBOOL();
+
+        return optionalTaskKey.map(taskKey -> new TaskDetail(taskKey, ignoreTaskFailure));
     }
 
-    public void saveToken(String table, String taskArn, String inputToken, long expireAt, String createdAt) {
+    public void saveTaskDetails(String table, String taskArn, String inputToken, boolean ignoreDmsTaskFailure, long expireAt, String createdAt) {
         AttributeValue expiryAttribute = new AttributeValue().withN(String.valueOf(expireAt));
+        AttributeValue ignoreDmsTaskFailureAttribute = new AttributeValue().withBOOL(ignoreDmsTaskFailure);
         Map<String, AttributeValue> item = Map
                 .of(
                         REPLICATION_TASK_ARN_KEY, new AttributeValue(taskArn),
+                        IGNORE_DMS_TASK_FAILURE_KEY, ignoreDmsTaskFailureAttribute,
                         TASK_TOKEN_KEY, new AttributeValue(inputToken),
                         CREATED_AT_KEY, new AttributeValue(createdAt),
                         EXPIRE_AT_KEY, expiryAttribute

--- a/src/main/java/uk/gov/justice/digital/common/TaskDetail.java
+++ b/src/main/java/uk/gov/justice/digital/common/TaskDetail.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.common;
+
+public class TaskDetail {
+
+    private final String token;
+    private final boolean ignoreFailure;
+
+    public TaskDetail(String token, boolean ignoreFailure) {
+        this.token = token;
+        this.ignoreFailure = ignoreFailure;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public boolean ignoreFailure() {
+        return ignoreFailure;
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/common/Utils.java
+++ b/src/main/java/uk/gov/justice/digital/common/Utils.java
@@ -12,9 +12,14 @@ public class Utils {
     public final static String TOKEN_EXPIRY_DAYS_KEY = "tokenExpiryDays";
     public final static long DEFAULT_TOKEN_EXPIRY_DAYS = 7;
     public final static String REPLICATION_TASK_ARN_KEY = "replicationTaskArn";
+    public final static String IGNORE_DMS_TASK_FAILURE_KEY = "ignoreDmsTaskFailure";
 
     public static Optional<String> getOptionalString(Map<String, Object> event, String key) {
         return Optional.ofNullable(event.get(key)).map(obj -> (String) obj);
+    }
+
+    public static boolean getBoolean(Map<String, Object> event, String key) {
+        return (boolean) event.getOrDefault(key, false);
     }
 
     @SuppressWarnings({"unchecked", "unused"})

--- a/src/main/java/uk/gov/justice/digital/lambda/StepFunctionDMSNotificationLambda.java
+++ b/src/main/java/uk/gov/justice/digital/lambda/StepFunctionDMSNotificationLambda.java
@@ -12,9 +12,17 @@ import uk.gov.justice.digital.services.StepFunctionDMSNotificationService;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static uk.gov.justice.digital.common.Utils.*;
+import static uk.gov.justice.digital.common.Utils.TASK_TOKEN_KEY;
+import static uk.gov.justice.digital.common.Utils.REPLICATION_TASK_ARN_KEY;
+import static uk.gov.justice.digital.common.Utils.IGNORE_DMS_TASK_FAILURE_KEY;
+import static uk.gov.justice.digital.common.Utils.TOKEN_EXPIRY_DAYS_KEY;
+import static uk.gov.justice.digital.common.Utils.DEFAULT_TOKEN_EXPIRY_DAYS;
+import static uk.gov.justice.digital.common.Utils.getOptionalString;
+import static uk.gov.justice.digital.common.Utils.getOrThrow;
+import static uk.gov.justice.digital.common.Utils.getBoolean;
 
 /**
  * Lambda function to notify AWS step function of DMS load completion.
@@ -27,23 +35,29 @@ import static uk.gov.justice.digital.common.Utils.*;
  * <pre>
  *  {
  *     "token": "some-step-function-task-token",
+ *     "ignoreDmsTaskFailure": false,
  *     "replicationTaskArn": "DMS replication task ARN",
  *     "tokenExpiryDays": "5"
  *  }
  * </pre>
- * <p>When received, the Lambda saves the token to dynamoDB using the replicationTaskArn value as key.
+ * <p>When received, the Lambda saves the token and the value of ignoreDmsTaskFailure to dynamoDB using the replicationTaskArn value as the key.
  * <li>ProcessDMSStoppage mode:
  * <p>This mode is invoked by the resulting cloudwatch event after the DMS load completes. The sample request is:
  *
  * <pre>
  *  {
- *     "resources": [ "DMS replication task ARN" ]
+ *     "resources": [ "DMS replication task ARN" ],
+ *     "detail": {
+ *         "eventId": "DMS-EVENT-0079"
+ *     }
  *  }
  * </pre>
  * <p>
- * This causes the Lambda to retrieve the taskToken from dynamoDB,
- * send a success notification to AWS the step function that the DMS load has completed,
+ * This causes the Lambda to retrieve the taskToken and the value of ignoreDmsTaskFailure from dynamoDB,
+ * send a notification to AWS the step function that the DMS load has completed,
  * and finally deletes the taskToken from dynamoDB.
+ * If ignoreDmsTaskFailure = true, then a success notification is sent irrespective of the eventId.
+ * If ignoreDmsTaskFailure = false and an eventId DMS-EVENT-0078 (DMS task failed) is received, then a failed notification is sent.
  * </ul>
  */
 public class StepFunctionDMSNotificationLambda implements RequestHandler<Map<String, Object>, Void> {
@@ -51,6 +65,8 @@ public class StepFunctionDMSNotificationLambda implements RequestHandler<Map<Str
     final static String DYNAMO_DB_TABLE = "dpr-step-function-tokens";
 
     public final static String CLOUDWATCH_EVENT_RESOURCES_KEY = "resources";
+    public final static String CLOUDWATCH_EVENT_DETAIL_KEY = "detail";
+    public final static String CLOUDWATCH_EVENT_ID_KEY = "eventId";
 
     private final StepFunctionDMSNotificationService service;
 
@@ -79,6 +95,8 @@ public class StepFunctionDMSNotificationLambda implements RequestHandler<Map<Str
         final String inputToken = getOptionalString(event, TASK_TOKEN_KEY).orElse("");
         final String taskArn = getOptionalString(event, REPLICATION_TASK_ARN_KEY)
                 .orElseGet(() -> getCloudWatchEventTaskArn(event));
+        final boolean ignoreDmsTaskFailure = getBoolean(event, IGNORE_DMS_TASK_FAILURE_KEY);
+        logger.log("Event received: " + event, LogLevel.DEBUG);
         // Optional number of days after which the token should be considered to have expired and will be deleted via TTL.
         // Only used for the start action when saving the token in DynamoDB.
         // When absent, defaults to DEFAULT_TOKEN_EXPIRY_DAYS.
@@ -87,10 +105,11 @@ public class StepFunctionDMSNotificationLambda implements RequestHandler<Map<Str
                 .orElse(DEFAULT_TOKEN_EXPIRY_DAYS);
 
         if (inputToken.isEmpty()) {
-            service.processStopEvent(logger, DYNAMO_DB_TABLE, REPLICATION_TASK_ARN_KEY, taskArn);
+            final String eventId = getStoppageEventId(event);
+            service.processStopEvent(logger, DYNAMO_DB_TABLE, REPLICATION_TASK_ARN_KEY, taskArn, eventId);
         } else {
             logger.log(String.format("Saving token %s to Dynamo table", inputToken), LogLevel.INFO);
-            service.registerTaskToken(inputToken, taskArn, DYNAMO_DB_TABLE, tokenExpiryDays);
+            service.registerTaskDetails(inputToken, taskArn, ignoreDmsTaskFailure, DYNAMO_DB_TABLE, tokenExpiryDays);
         }
 
         logger.log("Done", LogLevel.INFO);
@@ -100,8 +119,18 @@ public class StepFunctionDMSNotificationLambda implements RequestHandler<Map<Str
 
     @SuppressWarnings("unchecked")
     private String getCloudWatchEventTaskArn(Map<String, Object> event) {
-        ArrayList<String> resources = (ArrayList<String>) event.get(CLOUDWATCH_EVENT_RESOURCES_KEY);
-        return resources.get(0);
+        ArrayList<String> resources = getOrThrow(event, CLOUDWATCH_EVENT_RESOURCES_KEY, ArrayList.class);
+        if (resources.isEmpty()) {
+            throw new RuntimeException("Could not find DMS task ARN. List of resources is empty");
+        } else {
+            return resources.get(0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String getStoppageEventId(Map<String, Object> event) {
+        LinkedHashMap<String, Object> eventDetail = getOrThrow(event, CLOUDWATCH_EVENT_DETAIL_KEY, LinkedHashMap.class);
+        return getOrThrow(eventDetail, CLOUDWATCH_EVENT_ID_KEY, String.class);
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationService.java
+++ b/src/main/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.logging.LogLevel;
 import uk.gov.justice.digital.clients.dynamo.DynamoDbClient;
 import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+import uk.gov.justice.digital.common.TaskDetail;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -19,6 +20,9 @@ public class StepFunctionDMSNotificationService {
     private final StepFunctionsClient stepFunctionsClient;
     private final Clock clock;
 
+    public final static String DMS_TASK_FAILURE_EVENT_ID = "DMS-EVENT-0078";
+    public final static String DMS_TASK_SUCCESS_EVENT_ID = "DMS-EVENT-0079";
+
     public StepFunctionDMSNotificationService(
             DynamoDbClient dynamoDbClient,
             StepFunctionsClient stepFunctionsClient,
@@ -29,26 +33,47 @@ public class StepFunctionDMSNotificationService {
         this.clock = clock;
     }
 
-    public void processStopEvent(LambdaLogger logger, String dynamoTable, String taskKey, String taskArn) {
+    public void processStopEvent(LambdaLogger logger, String dynamoTable, String taskKey, String taskArn, String eventId) {
         Map<String, AttributeValue> itemKey = Map.of(taskKey, new AttributeValue(taskArn));
-        logger.log("Getting token from Dynamo table", LogLevel.INFO);
-        Optional<String> retrievedToken = dynamoDbClient.retrieveToken(dynamoTable, itemKey);
+        logger.log("Getting details from Dynamo table", LogLevel.INFO);
+        Optional<TaskDetail> optionalTaskDetail = dynamoDbClient.retrieveTaskDetail(dynamoTable, itemKey);
 
-        retrievedToken.ifPresent(token -> {
-                    logger.log(String.format("Notifying step functions of success using token %s", token), LogLevel.INFO);
-                    stepFunctionsClient.notifyStepFunctionSuccess(token);
+        optionalTaskDetail.ifPresentOrElse(taskDetail -> {
+            if (eventId.equalsIgnoreCase(DMS_TASK_FAILURE_EVENT_ID)) {
+                if (taskDetail.ignoreFailure()) {
+                    logger.log(String.format("Ignoring failure %s for DMS task %s", DMS_TASK_FAILURE_EVENT_ID, taskArn), LogLevel.INFO);
+                    processSuccessfulStopEvent(logger, taskDetail);
+                } else {
+                    String errorMessage = String.format("Failing function due to failure %s for DMS task %s", DMS_TASK_FAILURE_EVENT_ID, taskArn);
+                    logger.log(errorMessage, LogLevel.ERROR);
+                    processFailedStopEvent(logger, taskDetail, errorMessage);
                 }
-        );
+            } else {
+                processSuccessfulStopEvent(logger, taskDetail);
+            }
+        }, () -> { throw new RuntimeException("No Task details found in Dynamo table for " + taskArn); });
 
         logger.log("Deleting retrieved token from Dynamo table", LogLevel.INFO);
         dynamoDbClient.deleteToken(dynamoTable, itemKey);
     }
 
-    public void registerTaskToken(String inputToken, String taskArn, String table, Long tokenExpiryDays) {
+    public void registerTaskDetails(String inputToken, String taskArn, boolean ignoreTaskFailure, String table, Long tokenExpiryDays) {
         LocalDateTime now = LocalDateTime.now(clock);
         String createdAt = now.format(DateTimeFormatter.ISO_DATE_TIME);
         long expireAt = now.plusDays(tokenExpiryDays).toEpochSecond(ZoneOffset.UTC);
 
-        dynamoDbClient.saveToken(table, taskArn, inputToken, expireAt, createdAt);
+        dynamoDbClient.saveTaskDetails(table, taskArn, inputToken, ignoreTaskFailure, expireAt, createdAt);
+    }
+
+    private void processSuccessfulStopEvent(LambdaLogger logger, TaskDetail taskDetail) {
+        String taskToken = taskDetail.getToken();
+        logger.log(String.format("Notifying step functions of success using token %s", taskToken), LogLevel.INFO);
+        stepFunctionsClient.notifyStepFunctionSuccess(taskToken);
+    }
+
+    private void processFailedStopEvent(LambdaLogger logger, TaskDetail taskDetail, String error) {
+        String taskToken = taskDetail.getToken();
+        logger.log(String.format("Notifying step functions of failure using token %s", taskToken), LogLevel.INFO);
+        stepFunctionsClient.notifyStepFunctionFailure(taskToken, error);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/services/StepFunctionDMSNotificationServiceTest.java
@@ -8,14 +8,25 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.clients.dynamo.DynamoDbClient;
 import uk.gov.justice.digital.clients.stepfunctions.StepFunctionsClient;
+import uk.gov.justice.digital.common.TaskDetail;
 
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.justice.digital.services.StepFunctionDMSNotificationService.DMS_TASK_FAILURE_EVENT_ID;
+import static uk.gov.justice.digital.services.StepFunctionDMSNotificationService.DMS_TASK_SUCCESS_EVENT_ID;
 import static uk.gov.justice.digital.services.test.Fixture.fixedClock;
 import static uk.gov.justice.digital.services.test.Fixture.fixedDateTime;
 
@@ -38,41 +49,72 @@ class StepFunctionDMSNotificationServiceTest {
 
     @BeforeEach
     public void setup() {
+        reset(mockDynamoDbClient, mockStepFunctionsClient, mockLambdaLogger);
         undertest = new StepFunctionDMSNotificationService(mockDynamoDbClient, mockStepFunctionsClient, fixedClock);
     }
 
     @Test
-    public void processStopEventShouldNotifyStepFunctionsAndDeleteToken() {
+    public void processStopEventShouldNotifyStepFunctionOfSuccessAndDeleteTokenWhenGivenSuccessEventId() {
         doNothing().when(mockLambdaLogger).log(anyString(), any());
-        when(mockDynamoDbClient.retrieveToken(eq(TABLE), any())).thenReturn(Optional.of(TOKEN));
+        when(mockDynamoDbClient.retrieveTaskDetail(eq(TABLE), any())).thenReturn(Optional.of(new TaskDetail(TOKEN, false)));
 
-        undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN);
+        undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN, DMS_TASK_SUCCESS_EVENT_ID);
 
         verify(mockStepFunctionsClient, times(1)).notifyStepFunctionSuccess(eq(TOKEN));
         verify(mockDynamoDbClient, times(1)).deleteToken(eq(TABLE), any());
+        verifyNoMoreInteractions(mockStepFunctionsClient);
+    }
+
+    @Test
+    public void processStopEventShouldNotifyStepFunctionOfFailureAndDeleteTokenWhenGivenFailedEventIdAndIgnoreFailureIsFalse() {
+        boolean ignoreFailure = false;
+        doNothing().when(mockLambdaLogger).log(anyString(), any());
+        when(mockDynamoDbClient.retrieveTaskDetail(eq(TABLE), any())).thenReturn(Optional.of(new TaskDetail(TOKEN, ignoreFailure)));
+
+        undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN, DMS_TASK_FAILURE_EVENT_ID);
+
+        verify(mockStepFunctionsClient, times(1)).notifyStepFunctionFailure(eq(TOKEN), anyString());
+        verify(mockDynamoDbClient, times(1)).deleteToken(eq(TABLE), any());
+        verifyNoMoreInteractions(mockStepFunctionsClient);
+    }
+
+    @Test
+    public void processStopEventShouldNotifyStepFunctionOfSuccessAndDeleteTokenWhenGivenFailedEventIdAndIgnoreFailureIsTrue() {
+        boolean ignoreFailure = true;
+        doNothing().when(mockLambdaLogger).log(anyString(), any());
+        when(mockDynamoDbClient.retrieveTaskDetail(eq(TABLE), any())).thenReturn(Optional.of(new TaskDetail(TOKEN, ignoreFailure)));
+
+        undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN, DMS_TASK_FAILURE_EVENT_ID);
+
+        verify(mockStepFunctionsClient, times(1)).notifyStepFunctionSuccess(eq(TOKEN));
+        verify(mockDynamoDbClient, times(1)).deleteToken(eq(TABLE), any());
+        verifyNoMoreInteractions(mockStepFunctionsClient);
     }
 
     @Test
     public void processStopEventShouldNotNotifyStepFunctionsWhenTokenIsNotPresent() {
         doNothing().when(mockLambdaLogger).log(anyString(), any());
-        when(mockDynamoDbClient.retrieveToken(eq(TABLE), any())).thenReturn(Optional.empty());
+        when(mockDynamoDbClient.retrieveTaskDetail(eq(TABLE), any())).thenReturn(Optional.empty());
 
-        undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN);
+        assertThrows(Exception.class, () -> undertest.processStopEvent(mockLambdaLogger, TABLE, "task-key", TASK_ARN, DMS_TASK_SUCCESS_EVENT_ID));
 
-        verify(mockDynamoDbClient, times(1)).deleteToken(eq(TABLE), any());
+        verify(mockDynamoDbClient, times(1)).retrieveTaskDetail(eq(TABLE), any());
         verifyNoInteractions(mockStepFunctionsClient);
+        verifyNoMoreInteractions(mockDynamoDbClient);
     }
 
     @Test
-    public void registerTaskTokenShouldSaveToken() {
+    public void registerTaskDetailsShouldSaveTaskDetails() {
+        boolean ignoreTaskFailure = false;
 
-        undertest.registerTaskToken(TOKEN, TASK_ARN, TABLE, TOKEN_EXPIRY_DAYS);
+        undertest.registerTaskDetails(TOKEN, TASK_ARN, ignoreTaskFailure, TABLE, TOKEN_EXPIRY_DAYS);
 
         verify(mockDynamoDbClient, times(1))
-                .saveToken(
+                .saveTaskDetails(
                         eq(TABLE),
                         eq(TASK_ARN),
                         eq(TOKEN),
+                        eq(ignoreTaskFailure),
                         eq(fixedDateTime.plusDays(TOKEN_EXPIRY_DAYS).toEpochSecond(ZoneOffset.UTC)),
                         eq(fixedDateTime.format(DateTimeFormatter.ISO_DATE_TIME))
                 );


### PR DESCRIPTION
This PR:
- Adds a boolean field `ignoreDmsTaskFailure` to allow the pipeline continue when the Full-Load DMS task fails. This is required when loading large tables where the Full-Load phase could fail and terminate the pipeline
- When `ignoreDmsTaskFailure = true` and the DMS event contains event Id `DMS-EVENT-0078` (DMS task stopped with a failure), the lambda notifies the pipeline to proceed 
- When `ignoreDmsTaskFailure = false` and the DMS event contains event Id `DMS-EVENT-0078`, the lambda fails the pipeline